### PR TITLE
Fix broken POST and PUT endpoints.

### DIFF
--- a/scripts/api/serializers.py
+++ b/scripts/api/serializers.py
@@ -138,13 +138,8 @@ class AppSerializer(serializers.ModelSerializer):
 		many=False,
 		write_only=True,
 		queryset=AndroidVersion.objects.all(),
-		source='content_rating'
+		source='android_version'
 	)
-
-	
-
-
-
 
 	app_genre = AppGenreSerializer(
 		source='app_genre_set', # Note use of _set
@@ -249,7 +244,7 @@ class AppSerializer(serializers.ModelSerializer):
 				continue
 			else:
 				AppGenre.objects \
-					.create(app=app,genre=genre)
+					.create(app_id=app_id,genre_id=new_id)
 
 		# Delete old unmatched country entries
 		for old_id in old_ids:
@@ -257,7 +252,7 @@ class AppSerializer(serializers.ModelSerializer):
 				continue
 			else:
 				AppGenre.objects \
-					.filter(app_id=app.app_id, genre_id=old_id) \
+					.filter(app_id=app_id, genre_id=old_id) \
 					.delete()
 
 		return instance


### PR DESCRIPTION
This PR fixes both the `create()` (POST) and `update`() (PUT) methods.  The first error linked the `android_version_id` property to the wrong serializer throwing a runtime error while the second set of errors referenced unknown objects resulting in yet another runtime error.